### PR TITLE
Copying codecov report to final image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,8 @@ jobs:
 
       - name: Upload codecov report
         run: |
-          export id=$(docker images --filter "label=test=true" -q | head -1)
-          docker create --name testcontainer $id
-          docker cp testcontainer:/app/TestBikedashboard/coverage.opencover.xml .
+          docker create --name testfilecontainer andmos/bikedashboard:$(git rev-parse --short HEAD)
+          docker cp testfilecontainer:/tmp/coverage.opencover.xml .
           bash <(curl -s https://codecov.io/bash)
 
       - name: Log in to the Container registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM mcr.microsoft.com/dotnet/sdk:7.0.202-alpine3.16 AS build-env
 WORKDIR /app
-LABEL test=true
 
 COPY src/BikeDashboard/BikeDashboard BikeDashboard
 COPY src/BikeDashboard/TestBikedashboard  TestBikedashboard
@@ -20,6 +19,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:7.0.4-alpine3.16
 ENV ASPNETCORE_ENVIRONMENT Production
 WORKDIR /app
 
+COPY --from=build-env /app/TestBikedashboard/coverage.opencover.xml /tmp/coverage.opencover.xml
 COPY --from=build-env /app/publish/ .
 
 EXPOSE 5000


### PR DESCRIPTION
Since buildx ignores the label from the multistage dockerfile, we need to copy the codecov-report with us to final image and extract it from there